### PR TITLE
Allow only one way of entry into a game

### DIFF
--- a/Clueless/Clueless/templates/home.html
+++ b/Clueless/Clueless/templates/home.html
@@ -9,11 +9,11 @@
 
         <div class="container">
             <div class="row">
-                <div class="col-xs-6">
+                <div class="col-xs-12" id="new-game">
             	    <h4>Start a new investigation</h4>
             	    <input class="btn btn-primary" type="button" value="Create Game" onclick="location.href='/customize/?game=create';" />
         	    </div>
-                <div class="col-xs-6">
+                <div class="col-xs-12" id="join-game">
             	    <h4>Join an existing investigation <small>({{ games_pending | safe }} open)</small></h4>
             	    <input class="btn btn-primary" type="button" value="Join Game" onclick="location.href='/customize/?game=join';" />
                 </div>
@@ -33,6 +33,17 @@
         console.log("Current data, per user:");
         console.log("Open games:", {{ games_pending | safe }});
         console.log("Games In Progress:", {{ games_in_progress | safe }});
+
+        $(document).ready(function() {
+            const openGames = {{ games_pending | safe }};
+            if (openGames === 0) {
+                $("#new-game").show();
+                $("#join-game").hide();
+            } else {
+                $("#new-game").hide();
+                $("#join-game").show();
+            }
+        });
     </script>
 
 {% endblock %}


### PR DESCRIPTION
In section 2.2.1 Use case: Start Game of our SRS, we said that either the system either presents the option to create a new game, if none are in progress, or if there is a game in progress, the system presents the option to join a game. I noticed we had both available, even though we don't support more than one game. 

If we figure out how to support more than one game, I can revert this.